### PR TITLE
Adding the ability for a React component name to have numbers

### DIFF
--- a/ComponentRegistry.tsx
+++ b/ComponentRegistry.tsx
@@ -49,7 +49,7 @@ export default class ComponentRegistry {
     }
 
     private mapClassToResourceType(componentClassName: string): string {
-        let parts: string[] = componentClassName.match(/([A-Z][a-z]*)/);
+        let parts: string[] = componentClassName.match(/([A-Z][a-z0-9]*)/);
         if (parts) {
             let resourceType: string = parts[0].toLocaleLowerCase();
             let rest: string = componentClassName.substring(parts[0].length);


### PR DESCRIPTION
We have a requirement that the components are to be named with numbers such as Module300, Module 301, etc. The current regex will register them both as 'myproject/components/module'. This PR will allow numbers in the module name, and will treat the numbers as part of the previous word part. Meaning the modules will now be registered at 'myproject/components/module300' and 'myproject/components/module300'. A component registered as MyModule300 would become ''myproject/components/my-module300'