### PR TITLE
fix: move JSON data from textarea to script

### DIFF
--- a/ComponentManager.tsx
+++ b/ComponentManager.tsx
@@ -38,9 +38,9 @@ export default class ComponentManager {
      * @param item
      */
         public initReactComponent(item: any, forceHydrate: boolean = false): void {
-        let textarea = this.document.getElementById(item.getAttribute("data-react-id")) as HTMLTextAreaElement;
-        if (textarea) {
-            let props: ComponentTreeConfig = JSON.parse(textarea.value);
+        let dataElement = this.document.getElementById(item.getAttribute("data-react-id"));
+        if (dataElement) {
+            let props: ComponentTreeConfig = JSON.parse(dataElement.innerHTML);
             if (forceHydrate || props.wcmmode === "disabled") {
                 let comp = this.registry.getComponent(props.resourceType);
                 if (comp === null) {
@@ -54,7 +54,7 @@ export default class ComponentManager {
                 }
             }
         } else {
-            console.error("React config with id '" + item.getAttribute("data-react-id") + "' has no corresponding textarea element.");
+            console.error("React config with id '" + item.getAttribute("data-react-id") + "' has no corresponding data script element.");
         }
     }
 

--- a/test/ComponentManagerTest.tsx
+++ b/test/ComponentManagerTest.tsx
@@ -22,7 +22,7 @@ describe("ComponentManager", () => {
             resourceType: "/components/test"
         };
 
-        let doc: Document = jsdom.jsdom("<html><div data-react-id='1'></div><textarea id='1'>" + JSON.stringify(data) + "</textarea></html>")
+        let doc: Document = jsdom.jsdom("<html><div data-react-id='1'></div><script id='1' type='application/json'>" + JSON.stringify(data) + "</script></html>");
 
         let cm: ComponentManager = new ComponentManager(null, null, doc);
 
@@ -63,7 +63,7 @@ describe("ComponentManager", () => {
             }
         }
 
-        let doc: Document = jsdom.jsdom("<html><div data-react data-react-id='1'></div><textarea id='1'>" + JSON.stringify(data) + "</textarea></html>")
+        let doc: Document = jsdom.jsdom("<html><div data-react data-react-id='1'></div><script id='1' type='application/json'>" + JSON.stringify(data) + "</script></html>");
 
         let cm: ComponentManager = new ComponentManager(registry, container, doc);
 


### PR DESCRIPTION
css prop `display:none` doesn't guarantee that the inner content is not indexed by search engines and/or read by screen readers