### PR TITLE
refactor: move json data from textarea to script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+*.iml
 .nyc_output
 coverage
 lib

--- a/src/ComponentManager.tsx
+++ b/src/ComponentManager.tsx
@@ -44,16 +44,19 @@ export class ComponentManager {
     id: string
   ): void {
     let nextItem = item.nextSibling;
-    while (nextItem && nextItem.nodeName.toLocaleLowerCase() !== 'textarea') {
+    while (nextItem && nextItem.nodeName.toLocaleLowerCase() !== 'script') {
       nextItem = nextItem.nextSibling;
     }
     if (!nextItem) {
-      throw new Error('cannot find textarea for component');
+      throw new Error('cannot find script for component');
     }
-    const textarea = nextItem as HTMLTextAreaElement;
+    const scriptElement = nextItem as HTMLScriptElement;
 
-    if (textarea) {
-      const props: ComponentTreeConfig = JSON.parse(textarea.value, reviverFn);
+    if (scriptElement) {
+      const props: ComponentTreeConfig = JSON.parse(
+        scriptElement.text,
+        reviverFn
+      );
 
       this.container.cache.mergeCache(props.cache);
 
@@ -93,7 +96,7 @@ export class ComponentManager {
     } else {
       console.error(
         `React config with id '${item.getAttribute('data-react-id')}' ` +
-          'has no corresponding textarea element.'
+          'has no corresponding script element.'
       );
     }
   }

--- a/src/__tests__/ComponentManagerTest.tsx
+++ b/src/__tests__/ComponentManagerTest.tsx
@@ -25,8 +25,8 @@ describe('ComponentManager', () => {
     };
 
     const doc: Document = new JSDOM(
-      '<html><div data-react></div><textarea>' +
-        `${JSON.stringify(data)}</textarea></html>`
+      '<html><div data-react></div><script type="application/json">' +
+        `${JSON.stringify(data)}</script></html>`
     ).window.document;
 
     const container = new Container(cache, new MockSling(cache));
@@ -72,8 +72,9 @@ describe('ComponentManager', () => {
     };
 
     const doc: Document = new JSDOM(
-      "<html><div data-react></div>Shouldn't be here<textarea>" +
-        `${JSON.stringify(data)}</textarea></html>`
+      "<html><div data-react></div>Shouldn't be here" +
+        '<script type="application/json">' +
+        `${JSON.stringify(data)}</script></html>`
     ).window.document;
 
     const cm: ComponentManager = new ComponentManager(registry, container);

--- a/src/__tests__/ResourceIncludeTest.tsx
+++ b/src/__tests__/ResourceIncludeTest.tsx
@@ -106,7 +106,7 @@ describe('ResourceInclude', () => {
     expect(wrapper.html()).to.equal(
       '<div data-react-text="text_root_0">' +
         '<include resourcetype="/components/something" ' +
-        'selectors="" path="//embed">' +
+        'selectors path="//embed">' +
         '</include>' +
         '</div>'
     );


### PR DESCRIPTION
css prop `display:none` doesn't guarantee that the inner content is not indexed by search engines and/or read by screen readers